### PR TITLE
remove the uri field from the geonames gazetter generation script

### DIFF
--- a/scripts/geonames_gaz_gen.py
+++ b/scripts/geonames_gaz_gen.py
@@ -84,7 +84,7 @@ def rows(reader, expand_ascii=True):
                 yield [
                     name,
                     f"id={row[0]}",
-                    f"uri=https://www.geonames.org/{row[0]}",
+#                    f"uri=https://www.geonames.org/{row[0]}",
                     f"lat={row[4]}",
                     f"lon={row[5]}"
                 ]


### PR DESCRIPTION
This PR removes the `uri` field from the Geonames gazetteer (by removing it from the generation script). There are two reasons for this:

1. Including the URI in every entry adds 1G to the size of the generated file!
2. including the field seemed to crash the process for caching the gazetteer

I'm assuming that although the error when the script crashed was not memory related, the extra large size might have contributed to the problem somewhere along the line. Given we have the Geonames ID in the `id` field we can easily generate the URI from the annotated result should we need it.