### PR TITLE
document and remove completely the generation of a URI field

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ As you can see the data is stored as a TSV (tab separated values) file, with
 the place name in the first column. Each of the other columns then contains a
 key/value pair separated by an `=`. Here we have shown a minimal example with
 just the ID of the entry in Pleiades and the lat/lon coordinates. You can add
-any other columns you wish and they will end up as part of the output. For
-example, it might be useful to add a URI column to provide a fully specified
-link to the resources; in this case that would be
-`https://pleiades.stoa.org/places/579885`.
+any other columns you wish and they will end up as part of the output. Whilst
+it might be tempting to add a URI column to fully specify the link to the
+external resources (for example, in this case
+`https://pleiades.stoa.org/places/579885`) we would advise against this as it
+causes the gazetteer file to balloon in size, which in turn means that the
+memory requirement for the application increases as well.

--- a/scripts/geonames_gaz_gen.py
+++ b/scripts/geonames_gaz_gen.py
@@ -84,7 +84,6 @@ def rows(reader, expand_ascii=True):
                 yield [
                     name,
                     f"id={row[0]}",
-#                    f"uri=https://www.geonames.org/{row[0]}",
                     f"lat={row[4]}",
                     f"lon={row[5]}"
                 ]

--- a/scripts/pleiades_gaz_gen.py
+++ b/scripts/pleiades_gaz_gen.py
@@ -73,7 +73,6 @@ def rows(reader):
                 yield [
                     entry,
                     "id="+element["id"],
-                    "uri=https://pleiades.stoa.org/places/"+element["id"],
                     "lat="+str(lat),
                     "lon="+str(lon),
                     "start="+str(name["start"]),


### PR DESCRIPTION
Adding a URI field to the gazetteer is a bad idea for numerous reasons. This PR removes it from both generation scripts and documents why.